### PR TITLE
Remove header section from frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,11 +49,6 @@
         </svg>
       </button>
 
-      <header>
-        <h1>Course Materials Assistant</h1>
-        <p class="subtitle">Ask questions about courses, instructors, and content</p>
-      </header>
-
       <div class="main-content">
         <!-- Left Sidebar -->
         <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -207,30 +207,6 @@ body {
   transform: rotate(0deg) scale(1);
 }
 
-/* Header */
-header {
-  padding: 1.5rem 2rem;
-  background: var(--background);
-  border-bottom: 1px solid var(--border-color);
-  flex-shrink: 0;
-}
-
-header h1 {
-  font-size: 1.75rem;
-  font-weight: 700;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-  margin: 0;
-}
-
-.subtitle {
-  font-size: 0.95rem;
-  color: var(--text-secondary);
-  margin-top: 0.5rem;
-}
-
 /* Main Content Area with Sidebar */
 .main-content {
   flex: 1;
@@ -1048,14 +1024,6 @@ details[open] .suggested-header::before {
 
   .chat-main {
     order: 1;
-  }
-
-  header {
-    padding: 1rem;
-  }
-
-  header h1 {
-    font-size: 1.5rem;
   }
 
   .chat-messages {


### PR DESCRIPTION
## Summary

This PR removes the header section from the frontend while preserving the theme toggle functionality.

## Changes
- Removed `<header>` element with "Course Materials Assistant" title and subtitle
- Removed all header CSS styling (main and responsive sections)
- Theme toggle button remains intact and fully functional

Fixes #4

Generated with [Claude Code](https://claude.ai/code)